### PR TITLE
Zmiana w teście struktur

### DIFF
--- a/struct/sygi/good/simple.lat
+++ b/struct/sygi/good/simple.lat
@@ -2,7 +2,7 @@ int main(){
     myC[] abcd = new myC[10];
     abcd[5] = new myC;
     abcd.length == 1;
-    if (abcd[4].field > 0){
+    if (abcd[5].field > 0){
         return abcd[7].length;
     }
     else {


### PR DESCRIPTION
We wcześniejszej formie u mnie się wywala (w runtime - segfault) - i chyba powinno, bo abcd[4] jest niezainicjalizowane.
